### PR TITLE
Update .gitignore and lab.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+frr/
 clab-mpls/
 backups/
 .working-configs/

--- a/lab.sh
+++ b/lab.sh
@@ -15,8 +15,8 @@ lab_check_requirements(){
         exit 1
     fi
     if ! lsmod | grep -q mpls_router; then
-        echo "Kernel module mpls_router is not available. Please load it using 'sudo modprobe mpls_router'."
-        exit 1
+        echo "Kernel module mpls_router is not available. Loading it..."
+        sudo modprobe mpls_router
     fi
     if ! command -v yq &> /dev/null; then
         echo "yq is not installed."

--- a/mpls.clab.yml
+++ b/mpls.clab.yml
@@ -12,7 +12,7 @@ topology:
   kinds:
     linux:
       type: linux
-      image: quay.io/frrouting/frr:10.0.1
+      image: registry.ayuda.la/public/frr:latest
       image-pull-policy: IfNotPresent
   
   nodes:


### PR DESCRIPTION
- Add 'frr/' to .gitignore to exclude the frr/ directory from version control.
- Modify lab.sh to load the mpls_router kernel module if it is not available.
- Update the image URL in mpls.clab.yml to use the latest version of the FRR container.